### PR TITLE
Implementing specific step size

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ pip2 install matplotlib # macOS
 
 Once you've [installed](#Installation) styx you can export data.
 My recommendation is to actually build the queries in the Prometheus UI
-only if you've played with the data there and you know which query is best, 
-copy the query and use it to export the data with styx. 
+only if you've played with the data there and you know which query is best,
+copy the query and use it to export the data with styx.
 
 #### CSV
 
@@ -61,7 +61,7 @@ styx gnuplot --duration 6h 'sum(go_goroutines)' > goroutines.gnuplot
 styx gnuplot --prometheus http://prom.example.com 'sum(go_goroutines)' > goroutines.gnuplot
 ```
 
-Once you have written the generated content into a file you can use this to 
+Once you have written the generated content into a file you can use this to
 edit and plot the graph:
 
 ```bash
@@ -79,7 +79,7 @@ styx matplotlib --duration 6h 'sum(go_goroutines)' > goroutines.py
 styx matplotlib --prometheus http://prom.example.com 'sum(go_goroutines)' > goroutines.py
 ```
 
-Once you have written the generated content into a file you can use this to 
+Once you have written the generated content into a file you can use this to
 edit and plot the graph:
 
 ```bash

--- a/gnuplot.go
+++ b/gnuplot.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/urfave/cli/v2"
@@ -18,7 +19,16 @@ func gnuplotAction(c *cli.Context) error {
 	end := start.Add(c.Duration("duration"))
 	prometheus := c.String("prometheus")
 
-	results, err := Query(prometheus, *start, end, c.Args().First())
+	// if resolution is not set, use 1s as default
+	resolution := c.Duration("resolution")
+	if resolution == 0 || resolution == time.Duration(0) {
+		resolution = time.Second
+	}
+	if resolution < time.Second {
+		return fmt.Errorf(color.RedString("resolution must be >= 1s"))
+	}
+
+	results, err := Query(prometheus, *start, end, resolution, c.Args().First())
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -18,22 +18,27 @@ func main() {
 	app.Action = exportAction
 	app.Flags = []cli.Flag{
 		&cli.DurationFlag{
-			Name:        "duration,d",
-			Usage:       "The duration to get timeseries from",
-			Value:       time.Hour,
+			Name:  "duration,d",
+			Usage: "The duration to get timeseries from",
+			Value: time.Hour,
 		},
 		&cli.TimestampFlag{
-			Name:        "start,s",
-			Usage:       "The start time to get timeseries from",
-			Layout: 	 "2006-01-02T15:04:05",
+			Name:   "start,s",
+			Usage:  "The start time to get timeseries from",
+			Layout: "2006-01-02T15:04:05",
+		},
+		&cli.DurationFlag{
+			Name:  "resolution,r",
+			Usage: "The requested resolution of the timeseries in seconds (default 1s)",
+			Value: time.Second,
 		},
 		&cli.BoolFlag{
-			Name:        "header",
-			Usage:       "Include a header into the csv file",
+			Name:  "header",
+			Usage: "Include a header into the csv file",
 		},
 		&cli.StringFlag{
-			Name:        "prometheus",
-			Value:       "http://localhost:9090",
+			Name:  "prometheus",
+			Value: "http://localhost:9090",
 		},
 	}
 
@@ -43,22 +48,27 @@ func main() {
 		Action: gnuplotAction,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:        "prometheus",
-				Value:       "http://localhost:9090",
+				Name:  "prometheus",
+				Value: "http://localhost:9090",
 			},
 			&cli.DurationFlag{
-				Name:        "duration,d",
-				Usage:       "The duration to get timeseries from",
-				Value:       time.Hour,
+				Name:  "duration,d",
+				Usage: "The duration to get timeseries from",
+				Value: time.Hour,
 			},
 			&cli.TimestampFlag{
-				Name:        "start,s",
-				Usage:       "The start time to get timeseries from",
-				Layout: 	 "2006-01-02T15:04:05",
+				Name:   "start,s",
+				Usage:  "The start time to get timeseries from",
+				Layout: "2006-01-02T15:04:05",
+			},
+			&cli.DurationFlag{
+				Name:  "resolution,r",
+				Usage: "The requested resolution of the timeseries in seconds (default 1s)",
+				Value: time.Second,
 			},
 			&cli.StringFlag{
-				Name:        "title",
-				Usage:       "Give the gnuplot graph a title",
+				Name:  "title",
+				Usage: "Give the gnuplot graph a title",
 			},
 		},
 	}, {
@@ -67,22 +77,27 @@ func main() {
 		Action: matplotlibAction,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:        "prometheus",
-				Value:       "http://localhost:9090",
+				Name:  "prometheus",
+				Value: "http://localhost:9090",
 			},
 			&cli.DurationFlag{
-				Name:        "duration,d",
-				Usage:       "The duration to get timeseries from",
-				Value:       time.Hour,
+				Name:  "duration,d",
+				Usage: "The duration to get timeseries from",
+				Value: time.Hour,
 			},
 			&cli.TimestampFlag{
-				Name:        "start,s",
-				Usage:       "The start time to get timeseries from",
-				Layout: 	 "2006-01-02T15:04:05",
+				Name:   "start,s",
+				Usage:  "The start time to get timeseries from",
+				Layout: "2006-01-02T15:04:05",
+			},
+			&cli.DurationFlag{
+				Name:  "resolution,r",
+				Usage: "The requested resolution of the timeseries in seconds (default 1s)",
+				Value: time.Second,
 			},
 			&cli.StringFlag{
-				Name:        "title",
-				Usage:       "Give the gnuplot graph a title",
+				Name:  "title",
+				Usage: "Give the gnuplot graph a title",
 			},
 		},
 	}}
@@ -101,9 +116,16 @@ func exportAction(c *cli.Context) error {
 	end := start.Add(c.Duration("duration"))
 	prometheus := c.String("prometheus")
 
+	// if resolution is not set, use 1s as default
+	resolution := c.Duration("resolution")
+	if resolution == 0 || resolution == time.Duration(0) {
+		resolution = time.Second
+	}
+	if resolution < time.Second {
+		return fmt.Errorf(color.RedString("resolution must be >= 1s"))
+	}
 	// fmt.Printf("Querying %s from %s to %s\n", c.Args().First(), *start, end)
-
-	results, err := Query(prometheus, *start, end, c.Args().First())
+	results, err := Query(prometheus, *start, end, resolution, c.Args().First())
 	if err != nil {
 		return err
 	}

--- a/matplotlib.go
+++ b/matplotlib.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/urfave/cli/v2"
@@ -17,8 +18,16 @@ func matplotlibAction(c *cli.Context) error {
 	start := c.Timestamp("start")
 	end := start.Add(c.Duration("duration"))
 	prometheus := c.String("prometheus")
+	// if resolution is not set, use 1s as default
+	resolution := c.Duration("resolution")
+	if resolution == 0 || resolution == time.Duration(0) {
+		resolution = time.Second
+	}
+	if resolution < time.Second {
+		return fmt.Errorf(color.RedString("resolution must be >= 1s"))
+	}
 
-	results, err := Query(prometheus, *start, end, c.Args().First())
+	results, err := Query(prometheus, *start, end, resolution, c.Args().First())
 	if err != nil {
 		return err
 	}

--- a/prometheus_test.go
+++ b/prometheus_test.go
@@ -8,17 +8,24 @@ import (
 )
 
 func TestSteps(t *testing.T) {
-	assert.Equal(t, 1, steps(time.Minute))
-	assert.Equal(t, 1, steps(5*time.Minute))
-	assert.Equal(t, 3, steps(15*time.Minute))
-	assert.Equal(t, 7, steps(30*time.Minute))
-	assert.Equal(t, 14, steps(time.Hour))
-	assert.Equal(t, 28, steps(2*time.Hour))
-	assert.Equal(t, 85, steps(6*time.Hour))
-	assert.Equal(t, 171, steps(12*time.Hour))
-	assert.Equal(t, 342, steps(24*time.Hour))
-	assert.Equal(t, 685, steps(48*time.Hour))
-	assert.Equal(t, 2400, steps(168*time.Hour))
+	assert.Equal(t, 1, steps(time.Second, time.Second))
+	assert.Equal(t, 1, steps(time.Second, time.Millisecond))
+	assert.Equal(t, 1, steps(time.Second, time.Microsecond))
+	assert.Equal(t, 1, steps(time.Minute, time.Second))
+	assert.Equal(t, 1, steps(time.Minute, time.Millisecond))
+	assert.Equal(t, 1, steps(time.Minute, time.Microsecond))
+	assert.Equal(t, 1, steps(time.Hour, time.Second))
+	assert.Equal(t, 2, steps(time.Duration(12800)*time.Second*3, 2*time.Second))
+	assert.Equal(t, 1, steps(time.Duration(12800)*time.Second*3, 2*time.Millisecond))
+	assert.Equal(t, 1, steps(time.Duration(12800)*time.Second*3, 2*time.Microsecond))
+	assert.Equal(t, 1, steps(time.Duration(12800)*time.Second*3, 2*time.Nanosecond))
+	assert.Equal(t, 1, steps(time.Duration(12800)*time.Second*3, 100*time.Nanosecond))
+
+	// test on the fly 2023-06-28T13:19:16' + 15m with various resolutions
+	assert.Equal(t, 60, steps(
+		time.Date(2023, 6, 28, 13, 34, 16, 0, time.UTC).Sub(
+			time.Date(2023, 6, 28, 13, 19, 16, 0, time.UTC)), 60*time.Second))
+
 }
 
 func TestMetricName(t *testing.T) {


### PR DESCRIPTION
Hi, this is a followup of PR #16 (Issue #15), and probably a duplicate of PR #2, although the code is now much newer and it wouldn't have made sense to start from there.

As asked, I implemented a 'resolution' flag that defines the steps of the timeseries, which defaults to 1s if not provided (or a sub-second Duration is provided).

I also updated the tests and reformatted the code using Golang's inbuilt formatter.

Please let me know if any additional modification is to be done.
