### PR TITLE
Set default value for `start`-Flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ func main() {
 			Name:   "start,s",
 			Usage:  "The start time to get timeseries from",
 			Layout: "2006-01-02T15:04:05",
+			Value: cli.NewTimestamp(time.Now().Truncate(time.Hour)),
 		},
 		&cli.DurationFlag{
 			Name:  "resolution,r",
@@ -60,6 +61,7 @@ func main() {
 				Name:   "start,s",
 				Usage:  "The start time to get timeseries from",
 				Layout: "2006-01-02T15:04:05",
+				Value: cli.NewTimestamp(time.Now().Truncate(time.Hour)),
 			},
 			&cli.DurationFlag{
 				Name:  "resolution,r",
@@ -89,6 +91,7 @@ func main() {
 				Name:   "start,s",
 				Usage:  "The start time to get timeseries from",
 				Layout: "2006-01-02T15:04:05",
+				Value: cli.NewTimestamp(time.Now().Truncate(time.Hour)),
 			},
 			&cli.DurationFlag{
 				Name:  "resolution,r",

--- a/main.go
+++ b/main.go
@@ -23,10 +23,11 @@ func main() {
 			Value: time.Hour,
 		},
 		&cli.TimestampFlag{
-			Name:   "start,s",
-			Usage:  "The start time to get timeseries from",
-			Layout: "2006-01-02T15:04:05",
-			Value: cli.NewTimestamp(time.Now().Truncate(time.Hour)),
+			Name:    "start,s",
+			Usage:   "The start time to get timeseries from",
+			Layout:  "2006-01-02T15:04:05",
+			Value:    cli.NewTimestamp(time.Now().Truncate(time.Hour)),
+			Timezone: time.Local,
 		},
 		&cli.DurationFlag{
 			Name:  "resolution,r",
@@ -58,10 +59,11 @@ func main() {
 				Value: time.Hour,
 			},
 			&cli.TimestampFlag{
-				Name:   "start,s",
-				Usage:  "The start time to get timeseries from",
-				Layout: "2006-01-02T15:04:05",
-				Value: cli.NewTimestamp(time.Now().Truncate(time.Hour)),
+				Name:     "start,s",
+				Usage:    "The start time to get timeseries from",
+				Layout:   "2006-01-02T15:04:05",
+				Value:    cli.NewTimestamp(time.Now().Truncate(time.Hour)),
+				Timezone: time.Local,
 			},
 			&cli.DurationFlag{
 				Name:  "resolution,r",
@@ -92,6 +94,7 @@ func main() {
 				Usage:  "The start time to get timeseries from",
 				Layout: "2006-01-02T15:04:05",
 				Value: cli.NewTimestamp(time.Now().Truncate(time.Hour)),
+				Timezone: time.Local,
 			},
 			&cli.DurationFlag{
 				Name:  "resolution,r",


### PR DESCRIPTION
Default value of the `start`-Flag is at: Now minus an hour.

So that with default flags, styx calculates the graph of the last hour.

The default value for this flag was missing, so that styx didn't know
the start value and throws a SIGSEGV.

Closes #17 